### PR TITLE
#105759 - Correction contrôles d'accès

### DIFF
--- a/app/helpers/wiki_backup_helper.rb
+++ b/app/helpers/wiki_backup_helper.rb
@@ -10,14 +10,12 @@ module WikiBackupHelper
   end
 
   def project_options
-    Rails.cache.fetch("project-tree-for-options-#{Project.maximum("updated_on").to_i}") do
-      ary = []
-      Project.project_tree(projects) do |project, level|
-        title = "#{level == 0 ? "" : "--" * level + " " }#{project.name}"
-        ary << [title, project.identifier, {"data-link-id" => "wiki_project_#{project.identifier}", "data-start-page" => project.wiki.start_page}]
-      end
-      ary
+    ary = []
+    Project.project_tree(projects) do |project, level|
+      title = "#{level == 0 ? "" : "--" * level + " " }#{project.name}"
+      ary << [title, project.identifier, {"data-link-id" => "wiki_project_#{project.identifier}", "data-start-page" => project.wiki.start_page}]
     end
+    ary
   end
 
   def project_pages_options(pages, node=nil, level = 0)

--- a/app/helpers/wiki_backup_helper.rb
+++ b/app/helpers/wiki_backup_helper.rb
@@ -39,7 +39,7 @@ module WikiBackupHelper
   def url_for(options = {})
     if options.is_a?(Hash)
       #patch links to wiki pages
-      if options[:controller] == 'wiki' && options[:context] != 'top_menu'
+      if options[:controller] == 'wiki' && options[:context] != 'top_menu' && options[:action] != 'new'
         options[:controller] = 'wiki_backup'
       end
       #patch links to attachments

--- a/spec/controllers/wiki_backup_controller_spec.rb
+++ b/spec/controllers/wiki_backup_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe WikiBackupController, type: :controller do
   fixtures :wikis, :wiki_pages, :wiki_contents, :wiki_content_versions,
-           :projects, :enabled_modules
+           :projects, :enabled_modules, :users, :roles, :members, :member_roles
 
   describe "#index" do
     it "redirects to the main project" do
@@ -22,32 +22,44 @@ describe WikiBackupController, type: :controller do
     let!(:start_page) { wiki.find_page(id=nil) }
     let!(:other_page) { wiki.find_page("Another_page") }
 
+    it "requires wiki view permission" do
+     private_project = Project.find(2)
+     unpermitted_user = User.find(3)
+     get :show, :params => {:project_id => private_project, :id => other_page.title}, session: { user_id: unpermitted_user.id }
+
+     expect(response.code).to eq "403"
+
+     permitted_user = User.find(2)      
+     get :show, :params => {:project_id => private_project, :id => other_page.title}, session: { user_id: permitted_user.id }
+     expect(response.code).to eq "200"
+    end
+
     it "display a wiki page" do
-      get :show, params: {:project_id => project, :id => other_page.title}
+      get :show, :params => {:project_id => project, :id => other_page.title}, session: { user_id: 1 }
       expect(assigns(:project)).to eq project
       expect(assigns(:wiki)).to eq wiki
       expect(assigns(:page)).to eq other_page
     end
 
     it "redirects to the wiki start page if no id" do
-      get :show, params: {:project_id => project}
+      get :show, params: {:project_id => project}, :session => { user_id: 1 }
       expect(response).to redirect_to wiki_backup_path(:project_id => project, :id => start_page.title, :format => :html)
     end
 
     it "gets latest content for a page" do
-      get :show, params: {:project_id => project, :id => other_page.title}
+      get :show, params: {:project_id => project, :id => other_page.title}, session: { user_id: 1 }
       expect(assigns(:content)).to be_present
     end
 
     it "doesn't break if page is blank" do
       WikiPage.delete_all
-      get :show, params: {:project_id => project}
+      get :show, params: {:project_id => project}, session: { user_id: 1 }
       expect(response.code).to eq "404"
     end
 
     it "doesn't break if content is blank" do
       WikiContent.delete_all
-      get :show, params: {:project_id => project, :id => start_page.title}
+      get :show, params: {:project_id => project, :id => start_page.title}, session: { user_id: 1 }
     end
   end
 end


### PR DESCRIPTION
Implémentation de la correction : 
  - Ajout d'un contrôle des autorisations à la consultations des wiki_backup
  - Suppression de la mise en cache de la liste des noms des projets sur le wiki_backup qui est responsable d'un comportement non attendu. En effet la liste des projets est spécifique à chaque utilisateur et ses permissions
  - Implémentation des tests